### PR TITLE
Feat/app build variants

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,1 @@
+!google-services.json

--- a/app-old.json
+++ b/app-old.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Elektronik",
     "slug": "elektron",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "orientation": "portrait",
     "icon": "./src/assets/images/icon.png",
     "scheme": "elektronik",

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,12 +1,17 @@
+import Constants from 'expo-constants'
+
 const IS_DEV = process.env.APP_VARIANT === 'development';
+const IS_DEV_FROM_CONST = Constants.expoConfig?.extra?.isDevelopmentClient
 const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
 const IS_BETA = process.env.APP_VARIANT === 'beta';
 
 const BASE_APP_ID = 'pl.krystian_wybranowski.elektronPlus'
 const BASE_APP_NAME = 'Elektronik'
 
+console.log(`App variant: ${process.env.APP_VARIANT}, isDev: ${IS_DEV}, isDevFromConst: ${IS_DEV_FROM_CONST}, isPreview: ${IS_PREVIEW}, isBeta: ${IS_BETA}`)
+
 const getUniqueIdentifier = () => {
-    if (IS_DEV) return `${BASE_APP_ID}.dev`
+    if (IS_DEV || IS_DEV_FROM_CONST) return `${BASE_APP_ID}.dev`
     if (IS_PREVIEW) return `${BASE_APP_ID}.preview`
 
     // No check for beta, because it should be able to download production version too
@@ -14,15 +19,15 @@ const getUniqueIdentifier = () => {
 }
 
 const getAppName = () => {
-    if (IS_DEV) return `${BASE_APP_NAME} (Dev)`
+    if (IS_DEV || IS_DEV_FROM_CONST) return `${BASE_APP_NAME} (Dev)`
     if (IS_PREVIEW) return `${BASE_APP_NAME} (Preview)`
     if (IS_BETA) return `${BASE_APP_NAME} (Beta)`
 
     return BASE_APP_NAME
 }
 
-module.exports = {
-  expo: {
+
+export default {
     name: getAppName(),
     slug: "elektron",
     version: "6.1.0",
@@ -31,70 +36,69 @@ module.exports = {
     scheme: "elektronik",
     userInterfaceStyle: "automatic",
     notification: {
-      icon: "./src/assets/images/splash-icon-dark.png",
-      color: "#032666",
-      iosDisplayInForeground: true
+        icon: "./src/assets/images/splash-icon-dark.png",
+        color: "#032666",
+        iosDisplayInForeground: true
     },
     ios: {
-      supportsTablet: true,
-      infoPlist: {
-        UIBackgroundModes: ["remote-notification"]
-      },
-      bundleIdentifier: getUniqueIdentifier()
+        supportsTablet: true,
+        infoPlist: {
+            UIBackgroundModes: ["remote-notification"]
+        },
+        bundleIdentifier: getUniqueIdentifier()
     },
     android: {
-      googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
-      softwareKeyboardLayoutMode: "resize",
-      adaptiveIcon: {
-        foregroundImage: "./src/assets/images/adaptive-icon.png",
-        backgroundColor: "#ffffff"
-      },
-      package: getUniqueIdentifier(),
-      versionCode: 62
+        googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
+        softwareKeyboardLayoutMode: "resize",
+        adaptiveIcon: {
+            foregroundImage: "./src/assets/images/adaptive-icon.png",
+            backgroundColor: "#ffffff"
+        },
+        package: getUniqueIdentifier(),
+        versionCode: 62
     },
     web: {
-      bundler: "metro",
-      output: "static",
-      favicon: "./src/assets/images/favicon.png"
+        bundler: "metro",
+        output: "static",
+        favicon: "./src/assets/images/favicon.png"
     },
     plugins: [
-      "@react-native-firebase/app",
-      "@react-native-firebase/messaging",
-      "expo-router",
-      "expo-localization",
-      [
-        "expo-build-properties",
-        {
-          android: {
-            usesCleartextTraffic: true
-          }
-        }
-      ],
-      [
-        "expo-splash-screen",
-        {
-          backgroundColor: "ffffff",
-          image: "./src/assets/images/splash-icon-light.png",
-          dark: {
-            image: "./src/assets/images/splash-icon-dark.png",
-            backgroundColor: "#1a1a1f"
-          },
-          imageWidth: 200
-        }
-      ]
+        "@react-native-firebase/app",
+        "@react-native-firebase/messaging",
+        "expo-router",
+        "expo-localization",
+        [
+            "expo-build-properties",
+            {
+                android: {
+                    usesCleartextTraffic: true
+                }
+            }
+        ],
+        [
+            "expo-splash-screen",
+            {
+                backgroundColor: "ffffff",
+                image: "./src/assets/images/splash-icon-light.png",
+                dark: {
+                    image: "./src/assets/images/splash-icon-dark.png",
+                    backgroundColor: "#1a1a1f"
+                },
+                imageWidth: 200
+            }
+        ]
     ],
     experiments: {
-      typedRoutes: true
+        typedRoutes: true
     },
     extra: {
-      router: {
-        origin: false
-      },
-      eas: {
-        projectId: "bd6c3fcd-4517-4f6e-a10d-5172653e8437"
-      },
-      APP_VARIANT: "development"
+        router: {
+            origin: false
+        },
+        eas: {
+            projectId: "bd6c3fcd-4517-4f6e-a10d-5172653e8437"
+        },
+        APP_VARIANT: process.env.APP_VARIANT || "development"
     },
     owner: "cybersecuritylab"
-  }
-};
+}

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,17 +1,14 @@
-import Constants from 'expo-constants'
-
-const IS_DEV = process.env.APP_VARIANT === 'development';
-const IS_DEV_FROM_CONST = Constants.expoConfig?.extra?.isDevelopmentClient
+const IS_DEV = process.env.APP_VARIANT === 'development' || process.env.NODE_ENV === 'development';
 const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
 const IS_BETA = process.env.APP_VARIANT === 'beta';
 
 const BASE_APP_ID = 'pl.krystian_wybranowski.elektronPlus'
 const BASE_APP_NAME = 'Elektronik'
 
-console.log(`App variant: ${process.env.APP_VARIANT}, isDev: ${IS_DEV}, isDevFromConst: ${IS_DEV_FROM_CONST}, isPreview: ${IS_PREVIEW}, isBeta: ${IS_BETA}`)
+console.log(`App variant: ${process.env.APP_VARIANT}, node_env: ${process.env.NODE_ENV}, isDev: ${IS_DEV}, isPreview: ${IS_PREVIEW}, isBeta: ${IS_BETA}`)
 
 const getUniqueIdentifier = () => {
-    if (IS_DEV || IS_DEV_FROM_CONST) return `${BASE_APP_ID}.dev`
+    if (IS_DEV) return `${BASE_APP_ID}.dev`
     if (IS_PREVIEW) return `${BASE_APP_ID}.preview`
 
     // No check for beta, because it should be able to download production version too
@@ -19,7 +16,7 @@ const getUniqueIdentifier = () => {
 }
 
 const getAppName = () => {
-    if (IS_DEV || IS_DEV_FROM_CONST) return `${BASE_APP_NAME} (Dev)`
+    if (IS_DEV) return `${BASE_APP_NAME} (Dev)`
     if (IS_PREVIEW) return `${BASE_APP_NAME} (Preview)`
     if (IS_BETA) return `${BASE_APP_NAME} (Beta)`
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,100 @@
+const IS_DEV = process.env.APP_VARIANT === 'development';
+const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
+const IS_BETA = process.env.APP_VARIANT === 'beta';
+
+const BASE_APP_ID = 'pl.krystian_wybranowski.elektronPlus'
+const BASE_APP_NAME = 'Elektronik'
+
+const getUniqueIdentifier = () => {
+    if (IS_DEV) return `${BASE_APP_ID}.dev`
+    if (IS_PREVIEW) return `${BASE_APP_ID}.preview`
+
+    // No check for beta, because it should be able to download production version too
+    return BASE_APP_ID
+}
+
+const getAppName = () => {
+    if (IS_DEV) return `${BASE_APP_NAME} (Dev)`
+    if (IS_PREVIEW) return `${BASE_APP_NAME} (Preview)`
+    if (IS_BETA) return `${BASE_APP_NAME} (Beta)`
+
+    return BASE_APP_NAME
+}
+
+module.exports = {
+  expo: {
+    name: getAppName(),
+    slug: "elektron",
+    version: "6.1.0",
+    orientation: "portrait",
+    icon: "./src/assets/images/icon.png",
+    scheme: "elektronik",
+    userInterfaceStyle: "automatic",
+    notification: {
+      icon: "./src/assets/images/splash-icon-dark.png",
+      color: "#032666",
+      iosDisplayInForeground: true
+    },
+    ios: {
+      supportsTablet: true,
+      infoPlist: {
+        UIBackgroundModes: ["remote-notification"]
+      },
+      bundleIdentifier: getUniqueIdentifier()
+    },
+    android: {
+      googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
+      softwareKeyboardLayoutMode: "resize",
+      adaptiveIcon: {
+        foregroundImage: "./src/assets/images/adaptive-icon.png",
+        backgroundColor: "#ffffff"
+      },
+      package: getUniqueIdentifier(),
+      versionCode: 62
+    },
+    web: {
+      bundler: "metro",
+      output: "static",
+      favicon: "./src/assets/images/favicon.png"
+    },
+    plugins: [
+      "@react-native-firebase/app",
+      "@react-native-firebase/messaging",
+      "expo-router",
+      "expo-localization",
+      [
+        "expo-build-properties",
+        {
+          android: {
+            usesCleartextTraffic: true
+          }
+        }
+      ],
+      [
+        "expo-splash-screen",
+        {
+          backgroundColor: "ffffff",
+          image: "./src/assets/images/splash-icon-light.png",
+          dark: {
+            image: "./src/assets/images/splash-icon-dark.png",
+            backgroundColor: "#1a1a1f"
+          },
+          imageWidth: 200
+        }
+      ]
+    ],
+    experiments: {
+      typedRoutes: true
+    },
+    extra: {
+      router: {
+        origin: false
+      },
+      eas: {
+        projectId: "bd6c3fcd-4517-4f6e-a10d-5172653e8437"
+      },
+      APP_VARIANT: "development"
+    },
+    owner: "cybersecuritylab"
+  }
+};

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,4 +1,10 @@
-const IS_DEV = process.env.APP_VARIANT === 'development' || process.env.NODE_ENV === 'development';
+const IS_DEV = process.env.APP_VARIANT === 'development' || (
+    process.env.NODE_ENV === 'development' && (
+        process.env.APP_VARIANT !== 'preview'
+        && process.env.APP_VARIANT !== 'beta'
+        && process.env.APP_VARIANT !== 'production'
+    ) 
+);
 const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
 const IS_BETA = process.env.APP_VARIANT === 'beta';
 

--- a/eas.json
+++ b/eas.json
@@ -9,12 +9,18 @@
       "distribution": "internal",
       "android": {
         "buildType": "apk"
+      },
+      "env": {
+        "APP_VARIANT": "development"
       }
     },
     "preview": {
       "distribution": "internal",
       "android": {
         "buildType": "apk"
+      },
+      "env": {
+        "APP_VARIANT": "preview"
       }
     },
     "beta-apk": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,5 @@
     "react-test-renderer": "18.2.0",
     "typescript": "~5.3.3"
   },
-  "private": true,
-  "packageManager": "pnpm@10.7.1+sha512.2d92c86b7928dc8284f53494fb4201f983da65f0fb4f0d40baafa5cf628fa31dae3e5968f12466f17df7e97310e30f343a648baea1b9b350685dafafffdf5808"
+  "private": true
 }

--- a/src/components/VersionIndicator.tsx
+++ b/src/components/VersionIndicator.tsx
@@ -16,11 +16,13 @@ export const VersionIndicator = ({ position = 'bottom' }: { position?: 'bottom' 
         })}>
             <Link href="/settings/debug" asChild>
                 <Pressable>
-                    <Text className="text-foreground-secondary text-sm text-center">{t('Settings.debug.version')}: {version}  ({buildNumber}) - {buildVariant === 'beta'
-                        ? t('Settings.debug.buildVariant.beta')
-                        : buildVariant === 'production'
-                            ? t('Settings.debug.buildVariant.production')
-                            : t('Settings.debug.buildVariant.dev')}</Text>
+                    <Text className="text-foreground-secondary text-sm text-center">{t('Settings.debug.version')}: {version}  ({buildNumber}) - {buildVariant === 'production'
+                        ? t('Settings.debug.buildVariant.production')
+                        : buildVariant === 'beta'
+                            ? t('Settings.debug.buildVariant.beta')
+                            : buildVariant === 'preview'
+                                ? t('Settings.debug.buildVariant.preview')
+                                : t('Settings.debug.buildVariant.dev')}</Text>
                 </Pressable>
             </Link>
             {(buildVariant !== 'production') && (

--- a/src/i18n/translations/pl.json
+++ b/src/i18n/translations/pl.json
@@ -77,8 +77,9 @@
       "heading": "Ustawienia Deweloperskie",
       "version": "Wersja",
       "buildVariant": {
-        "beta": "Beta",
         "production": "Stabilna",
+        "beta": "Beta",
+        "preview": "Preview",
         "dev": "Deweloperska",
         "betaDisclaimer": "To jest wersja beta. Możesz napotkać błędy - <redirect>pamiętaj, aby je zgłaszać</redirect>."
       }

--- a/src/utils/buildInfo.ts
+++ b/src/utils/buildInfo.ts
@@ -1,12 +1,12 @@
 import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 
-type BuildVariant = 'development' | 'beta' | 'production' | 'unknown';
+type BuildVariant = 'development' | 'beta' | 'production' | 'unknown' | 'preview';
 
 export function getBuildVariant(): BuildVariant {
   // Sprawdź zmienną środowiskową APP_VARIANT
   const variant = Constants.expoConfig?.extra?.APP_VARIANT;
-  if (variant === 'beta' || variant === 'production') {
+  if (variant === 'beta' || variant === 'production' || variant === 'preview') {
     return variant;
   }
   


### PR DESCRIPTION
Added build variants:
- special name and package name to diffrent versions (development, preview, beta apk/store, production) for many instances of one app and better beta testing
- new npm script for better local build process
- move from `app.json` to `app.config.ts`
- creation of `.easignore` to allow local google-services when building app (also available in EAS env using `eas env:pull`)